### PR TITLE
Oracle8u121 Upgrade

### DIFF
--- a/vars/RedHat-Oracle-8.yml
+++ b/vars/RedHat-Oracle-8.yml
@@ -2,6 +2,6 @@
 
 __java_oracle_rpm: java8u121
 __java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.rpm
-__java_oracle_download_checksum: md5:ee64193f3aa2092d44fbfb7a61b09290
+__java_oracle_download_checksum: md5:de86e326f9fd98f080cd355081b4a3dc
 
 java_home: /usr/java/latest

--- a/vars/RedHat-Oracle-8.yml
+++ b/vars/RedHat-Oracle-8.yml
@@ -1,7 +1,7 @@
 ---
 
-__java_oracle_rpm: java8u112
-__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.rpm
-__java_oracle_download_checksum: md5:25b37dc93828cc24e2c246cf6f4a5aac
+__java_oracle_rpm: java8u121
+__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.rpm
+__java_oracle_download_checksum: md5:ee64193f3aa2092d44fbfb7a61b09290
 
 java_home: /usr/java/latest

--- a/vars/Suse-Oracle-8.yml
+++ b/vars/Suse-Oracle-8.yml
@@ -1,8 +1,8 @@
 ---
 
-__java_oracle_tar: jdk-8u112-linux-x64.tar.gz
-__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.tar.gz
-__java_oracle_download_checksum: md5:de9b7a90f0f5a13cfcaa3b01451d0337
-__java_oracle_directory: jdk1.8.0_112
+__java_oracle_tar: jdk-8u121-linux-x64.tar.gz
+__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
+__java_oracle_download_checksum: md5:093e22e4f0a55420780a0e437ab9fcd4
+__java_oracle_directory: jdk1.8.0_121
 
 java_home: /usr/java/latest

--- a/vars/Suse-Oracle-8.yml
+++ b/vars/Suse-Oracle-8.yml
@@ -2,7 +2,7 @@
 
 __java_oracle_tar: jdk-8u121-linux-x64.tar.gz
 __java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
-__java_oracle_download_checksum: md5:093e22e4f0a55420780a0e437ab9fcd4
+__java_oracle_download_checksum: md5:91972fb4e753f1b6674c2b952d974320
 __java_oracle_directory: jdk1.8.0_121
 
 java_home: /usr/java/latest

--- a/vars/default-Oracle-8.yml
+++ b/vars/default-Oracle-8.yml
@@ -1,8 +1,8 @@
 ---
 
-__java_oracle_tar: jdk-8u112-linux-x64.tar.gz
-__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.tar.gz
-__java_oracle_download_checksum: md5:de9b7a90f0f5a13cfcaa3b01451d0337
-__java_oracle_directory: jdk1.8.0_112
+__java_oracle_tar: jdk-8u121-linux-x64.tar.gz
+__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
+__java_oracle_download_checksum: md5:093e22e4f0a55420780a0e437ab9fcd4
+__java_oracle_directory: jdk1.8.0_121
 
 java_home: /usr/java/latest

--- a/vars/default-Oracle-8.yml
+++ b/vars/default-Oracle-8.yml
@@ -2,7 +2,7 @@
 
 __java_oracle_tar: jdk-8u121-linux-x64.tar.gz
 __java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
-__java_oracle_download_checksum: md5:093e22e4f0a55420780a0e437ab9fcd4
+__java_oracle_download_checksum: md5:91972fb4e753f1b6674c2b952d974320
 __java_oracle_directory: jdk1.8.0_121
 
 java_home: /usr/java/latest


### PR DESCRIPTION
Switch from Oracle Java 8u112 to 8u121 addresses [critical security patches](http://www.oracle.com/technetwork/security-advisory/cpujan2017-2881727.html)