### PR TITLE
Update Java Home Template for PATH Override

### DIFF
--- a/templates/java_home.sh.j2
+++ b/templates/java_home.sh.j2
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export JAVA_HOME={{ java_home }}
-export PATH={{ java_home }}:${PATH}
+export PATH={{ java_home }}/bin:${PATH}


### PR DESCRIPTION
Path was incorrectly being set and is being applied by alternatives. While this method is correct eventually for the time being this fixes the original intent of the role.

Fixes #12 