### PR TITLE
MAJ vars for jdk 8

### DIFF
--- a/vars/RedHat-Oracle-8.yml
+++ b/vars/RedHat-Oracle-8.yml
@@ -1,7 +1,7 @@
 ---
 
-__java_oracle_rpm: java8u121
-__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.rpm
-__java_oracle_download_checksum: md5:de86e326f9fd98f080cd355081b4a3dc
+__java_oracle_rpm: java8u131
+__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm
+__java_oracle_download_checksum: md5:9024d13ec651d07de450d465f14065a6
 
 java_home: /usr/java/latest

--- a/vars/Suse-Oracle-8.yml
+++ b/vars/Suse-Oracle-8.yml
@@ -1,8 +1,8 @@
 ---
 
-__java_oracle_tar: jdk-8u121-linux-x64.tar.gz
-__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
-__java_oracle_download_checksum: md5:91972fb4e753f1b6674c2b952d974320
-__java_oracle_directory: jdk1.8.0_121
+__java_oracle_tar: jdk-8u131-linux-x64.tar.gz
+__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
+__java_oracle_download_checksum: md5:75b2cb2249710d822a60f83e28860053
+__java_oracle_directory: jdk1.8.0_131
 
 java_home: /usr/java/latest

--- a/vars/default-Oracle-8.yml
+++ b/vars/default-Oracle-8.yml
@@ -1,8 +1,8 @@
 ---
 
-__java_oracle_tar: jdk-8u121-linux-x64.tar.gz
-__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
-__java_oracle_download_checksum: md5:91972fb4e753f1b6674c2b952d974320
-__java_oracle_directory: jdk1.8.0_121
+__java_oracle_tar: jdk-8u131-linux-x64.tar.gz
+__java_oracle_download: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
+__java_oracle_download_checksum: md5:75b2cb2249710d822a60f83e28860053
+__java_oracle_directory: jdk1.8.0_131
 
 java_home: /usr/java/latest


### PR DESCRIPTION
I update vars for Oracle jdk 8

But also, I have seen that jdk 7 don't work because Oracle pass the jdk 7 in older version (the link changes)  I tried to fix it but no success for now
So for now all the role don't work with Java 7.