### PR TITLE
Add Oracle jdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,6 +149,78 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: Ubuntu
     distribution_version: yakkety
+    version: "9"
+    type: Oracle
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Ubuntu
+    distribution_version: xenial
+    version: "9"
+    type: Oracle
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Ubuntu
+    distribution_version: trusty
+    version: "9"
+    type: Oracle
+    init: /sbin/init
+    run_opts: ""
+  - distribution: Ubuntu
+    distribution_version: precise
+    version: "9"
+    type: Oracle
+    init: /sbin/init
+    run_opts: ""
+  - distribution: EL
+    distribution_version: "7"
+    version: "9"
+    type: Oracle
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: EL
+    distribution_version: "6"
+    version: "9"
+    type: Oracle
+    init: /sbin/init
+    run_opts: ""
+  - distribution: Debian
+    distribution_version: jessie
+    version: "9"
+    type: Oracle
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Fedora
+    distribution_version: "24"
+    version: "9"
+    type: Oracle
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Fedora
+    distribution_version: "23"
+    version: "9"
+    type: Oracle
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "7"
+    version: "9"
+    type: Oracle
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "6"
+    version: "9"
+    type: Oracle
+    init: /sbin/init
+    run_opts: ""
+  - distribution: opensuse
+    distribution_version: "42.2"
+    version: "9"
+    type: Oracle
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Ubuntu
+    distribution_version: yakkety
     version: "8"
     type: Oracle
     init: /lib/systemd/systemd

--- a/vars/RedHat-Oracle-9.yml
+++ b/vars/RedHat-Oracle-9.yml
@@ -1,0 +1,7 @@
+---
+
+__java_oracle_rpm: java9+175
+__java_oracle_download: http://download.java.net/java/jdk9/archive/175/binaries/jdk-9+175_linux-x64_bin.tar.gz
+__java_oracle_download_checksum: sha256:18621c516c4f4c84b8bf65d7e7cdadd5e2ae80f16dfe9faa4ff0b7e7fb81cbd9
+
+java_home: /usr/java/latest

--- a/vars/Suse-Oracle-9.yml
+++ b/vars/Suse-Oracle-9.yml
@@ -1,0 +1,8 @@
+---
+
+__java_oracle_tar: jdk-9+175-linux-x64.tar.gz
+__java_oracle_download: http://download.java.net/java/jdk9/archive/175/binaries/jdk-9+175_linux-x64_bin.tar.gz
+__java_oracle_download_checksum: sha256:18621c516c4f4c84b8bf65d7e7cdadd5e2ae80f16dfe9faa4ff0b7e7fb81cbd9
+__java_oracle_directory: jdk-9
+
+java_home: /usr/java/latest

--- a/vars/default-Oracle-9.yml
+++ b/vars/default-Oracle-9.yml
@@ -1,0 +1,8 @@
+---
+
+__java_oracle_tar: jdk-9+175-linux-x64.tar.gz
+__java_oracle_download: http://download.java.net/java/jdk9/archive/175/binaries/jdk-9+175_linux-x64_bin.tar.gz
+__java_oracle_download_checksum: sha256:18621c516c4f4c84b8bf65d7e7cdadd5e2ae80f16dfe9faa4ff0b7e7fb81cbd9
+__java_oracle_directory: jdk-9
+
+java_home: /usr/java/latest


### PR DESCRIPTION
I add Oracle jdk9.
I tested it on Ubuntu and Centos, it works
But non on Suse and RedHat
I was thinking that tests will be launch automatically

I just read that the stable version will be available the 27 July, I will do an other PR to add it at this moment